### PR TITLE
Dev 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 sudo: false
 
+git:
+  depth: 3
+
 matrix:
   include:
     - php: 7.1

--- a/src/Helpers/TypeEqualityHelperMethods.php
+++ b/src/Helpers/TypeEqualityHelperMethods.php
@@ -54,7 +54,7 @@ trait TypeEqualityHelperMethods
             ));
         }
 
-        return ($this->getType() === $type->getType()) ? true : false;
+        return ($this::getType() === $type::getType()) ? true : false;
     }
 
     /**

--- a/src/Helpers/TypeEqualityHelperMethods.php
+++ b/src/Helpers/TypeEqualityHelperMethods.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of the Type package.
+ * For the full copyright information please view the LICENCE file that was
+ * distributed with this package.
+ *
+ * @copyright Simon Deeley 2017
+ */
+
+namespace simondeeley\Helpers;
+
+use RuntimeException;
+use simondeeley\Type\Type;
+use simondeeley\Type\TypeEquality;
+
+/**
+ * Helper methods for TypeEquality
+ *
+ * This trait provides methods which utilise the flags described in
+ * {@link TypeEquality} that can be called from TypeEquality::equals to help
+ * determine if two objects are equal.
+ *
+ * @uses Type
+ * @uses TypeEquality
+ * @author Simon Deeley <s.deeley@icloud.com>
+ */
+trait TypeEqualityHelperMethods
+{
+    /**
+     * Check against Type::getType
+     *
+     * Makes a comparison between two objects using the return values of
+     * {@link Type::getType}. If both are equal then the method returns true,
+     * otherwise false. Note that this method also returns true if the passed
+     * flags are set to ignore this tye check.
+     *
+     * @param Type $type - the object to check against
+     * @param int|null $flags - optional flags enable or disable certain checks
+     * @return bool - Returns true if types are equal
+     * @throws RuntimeException - if $this is not an instance of {@link Type}
+     */
+    final private function isSameTypeAs(Type $type, int $flags = null): bool
+    {
+        if ($flags & TypeEquality::IGNORE_OBJECT_TYPE) {
+            return true; // Ignore this check and just return true
+        }
+
+        if (false === $this instanceof Type) {
+            throw new RuntimeException(sprintf(
+                'Cannot compare type equality as %s does not implement %s',
+                get_class($this),
+                Type::class
+            ));
+        }
+
+        return ($this->getType() === $type->getType()) ? true : false;
+    }
+
+    /**
+     * Check against an objects ID
+     *
+     * Makes a comparison against an objects identity, obtained through the use
+     * of spl_object_hash. Method returns true if both objects point to the
+     * same PHP reference. Note that this method also returns true when the $flag
+     * is set to ignore this type of check.
+     *
+     * @param Type $type - the object to check against
+     * @param int|null $flags - optional flags enable or disable certain checks
+     * @return bool - Returns true if identities are equal
+     */
+    final private function isSameObjectAs(Type $type, int $flags = null): bool
+    {
+        if ($flags & TypeEquality::IGNORE_OBJECT_IDENTITY) {
+            return true;
+        }
+
+        return (spl_object_hash($this) === spl_object_hash($type)) ? true : false;
+    }
+}

--- a/src/Type/TypeEquality.php
+++ b/src/Type/TypeEquality.php
@@ -14,7 +14,19 @@ namespace simondeeley\Type;
  * Compare equality between two Type objects
  *
  * Interface for objects that can compare an object with itself to determine
- * if the two objects are equal.
+ * if the two objects are equal. Uses bitwise flags to optionally exclude
+ * comparisons that may be useful in comparing type equality. The following
+ * flags are available:
+ *
+ * TypeEquality::IGNORE_OBJECT_TYPE - Set this flag to ignore the type of the
+ * object which is set by Type::getType.
+ *
+ * TypeEquality::IGNORE_OBJECT_IDENTITY - Set this flag to ignore checking that
+ * an object points to the same PHP reference, for example by checking the value
+ * obtained by invoking spl_object_hash.
+ *
+ * Bitwise operators can be combined by using the pipe '|' operator, for example
+ * $foo->equals($bar, TypeEquality::IGNORE_OBJECT_TYPE | TypeEquality::IGNORE_OBJECT_IDENTITY)
  *
  * @author Simon Deeley <s.deeley@icloud.com>
  */

--- a/src/Type/TypeEquality.php
+++ b/src/Type/TypeEquality.php
@@ -49,5 +49,5 @@ interface TypeEquality
      * @return bool - Returns true if objects are equal
      * @throws InvalidArgumentException - Thrown if objects cannot be compared
      */
-    public function equals(Type $object, int $flags = TypeEquality::IGNORE_OBJECT_IDENTITY): bool;
+    public function equals(Type $object, int $flags = self::IGNORE_OBJECT_IDENTITY): bool;
 }

--- a/src/Type/TypeEquality.php
+++ b/src/Type/TypeEquality.php
@@ -20,7 +20,8 @@ namespace simondeeley\Type;
  */
 interface TypeEquality
 {
-    const STRICT_COMPARISON = 1;
+    const IGNORE_OBJECT_TYPE = 0b0001;
+    const IGNORE_OBJECT_IDENTITY = 0b0010;
 
     /**
      * Compare two {@link Type} objects

--- a/src/Type/TypeEquality.php
+++ b/src/Type/TypeEquality.php
@@ -20,6 +20,8 @@ namespace simondeeley\Type;
  */
 interface TypeEquality
 {
+    const STRICT_COMPARISON = 1;
+
     /**
      * Compare two {@link Type} objects
      *
@@ -29,8 +31,10 @@ interface TypeEquality
      * an exception if an error occurrs when trying to compare the objects.
      *
      * @param Type $object - An object to test equality against
+     * @param int|null $flags - Optional settings which can be passed to alter
+     *                          the behaviour of the method
      * @return bool - Returns true if objects are equal
      * @throws InvalidArgumentException - Thrown if objects cannot be compared
      */
-    public function equals(Type $object): bool;
+    public function equals(Type $object, int $flags = null): bool;
 }

--- a/src/Type/TypeEquality.php
+++ b/src/Type/TypeEquality.php
@@ -44,10 +44,10 @@ interface TypeEquality
      * an exception if an error occurrs when trying to compare the objects.
      *
      * @param Type $object - An object to test equality against
-     * @param int|null $flags - Optional settings which can be passed to alter
-     *                          the behaviour of the method
+     * @param int $flags - Optional settings which can be passed to alter
+     *                     the behaviour of the method
      * @return bool - Returns true if objects are equal
      * @throws InvalidArgumentException - Thrown if objects cannot be compared
      */
-    public function equals(Type $object, int $flags = null): bool;
+    public function equals(Type $object, int $flags = TypeEquality::IGNORE_OBJECT_IDENTITY): bool;
 }

--- a/tests/Helpers/TypeEqualityHelperMethodsTest.php
+++ b/tests/Helpers/TypeEqualityHelperMethodsTest.php
@@ -54,8 +54,11 @@ final class TypeEqualityHelperMethodsTest extends TestCase
     final public function shouldThrowAnException(): void
     {
         $subject = new class { // Note does not implement correct interface
-            use TypeEqualityHelperMethods {
-                isSameTypeAs as public foo;
+            use TypeEqualityHelperMethods;
+
+            final public function foo(Type $type, int $flags): bool
+            {
+                return $this->isSameTypeAs($type, $flags);
             }
         };
 
@@ -78,12 +81,16 @@ final class TypeEqualityHelperMethodsTest extends TestCase
     final public function sameTypeMethodData(): array
     {
         $one = new class implements Type {
-            use TypeEqualityHelperMethods {
-                isSameTypeAs as public foo;
+            use TypeEqualityHelperMethods;
+
+            final public function foo(Type $type, int $flags): bool
+            {
+                return $this->isSameTypeAs($type, $flags);
             }
 
-            use TypeEqualityHelperMethods {
-                isSameObjectAs as public bar;
+            final public function bar(Type $type, int $flags): bool
+            {
+                return $this->isSameObjectAs($type, $flags);
             }
 
             final public static function getType(): string

--- a/tests/Helpers/TypeEqualityHelperMethodsTest.php
+++ b/tests/Helpers/TypeEqualityHelperMethodsTest.php
@@ -39,8 +39,8 @@ final class TypeEqualityHelperMethodsTest extends TestCase
      */
     final public function methodsShouldReturnCorrectBooleanValue(Type $subject, Type $target, int $flags, bool $isSameTypeAs, bool $isSameObjectAs): void
     {
-        $this->assertEquals($isSameTypeAs, $subject->isSameTypeAs($target, $flags));
-        $this->assertEquals($isSameObjectAs, $subject->isSameObjectAs($target, $flags));
+        $this->assertEquals($isSameTypeAs, $subject->foo($target, $flags));
+        $this->assertEquals($isSameObjectAs, $subject->bar($target, $flags));
     }
 
     /**
@@ -55,7 +55,7 @@ final class TypeEqualityHelperMethodsTest extends TestCase
     {
         $subject = new class { // Note does not implement correct interface
             use TypeEqualityHelperMethods {
-                isSameTypeAs as public isSameTypeAs;
+                isSameTypeAs as public foo;
             }
         };
 
@@ -66,7 +66,7 @@ final class TypeEqualityHelperMethodsTest extends TestCase
             }
         };
 
-        $subject->isSameTypeAs($target);
+        $subject->foo($target);
     }
 
     /**
@@ -79,11 +79,11 @@ final class TypeEqualityHelperMethodsTest extends TestCase
     {
         $one = new class implements Type {
             use TypeEqualityHelperMethods {
-                isSameTypeAs as public isSameTypeAs;
+                isSameTypeAs as public foo;
             }
 
             use TypeEqualityHelperMethods {
-                isSameObjectAs as public isSameObjectAs;
+                isSameObjectAs as public bar;
             }
 
             final public static function getType(): string
@@ -93,14 +93,6 @@ final class TypeEqualityHelperMethodsTest extends TestCase
         };
 
         $two = new class implements Type {
-            use TypeEqualityHelperMethods {
-                isSameTypeAs as public isSameTypeAs;
-            }
-
-            use TypeEqualityHelperMethods {
-                isSameObjectAs as public isSameObjectAs;
-            }
-
             final public static function getType(): string
             {
                 return 'test';
@@ -108,14 +100,6 @@ final class TypeEqualityHelperMethodsTest extends TestCase
         };
 
         $three = new class implements Type {
-            use TypeEqualityHelperMethods {
-                isSameTypeAs as public isSameTypeAs;
-            }
-
-            use TypeEqualityHelperMethods {
-                isSameObjectAs as public isSameObjectAs;
-            }
-
             final public static function getType(): string
             {
                 return 'bar';

--- a/tests/Helpers/TypeEqualityHelperMethodsTest.php
+++ b/tests/Helpers/TypeEqualityHelperMethodsTest.php
@@ -1,0 +1,199 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of the Type package.
+ * For the full copyright information please view the LICENCE file that was
+ * distributed with this package.
+ *
+ * @copyright Simon Deeley 2017
+ */
+
+namespace simondeeley\Tests\Helpers;
+
+use simondeeley\Type\Type;
+use simondeeley\Type\TypeEquality;
+use simondeeley\Helpers\TypeEqualityHelperMethods;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test cases for TestEquality helper methods
+ *
+ * @uses TestCase
+ * @final
+ * @author Simon Deeley <s.deeley@icloud.com>
+ */
+final class TypeEqualityHelperMethodsTest extends TestCase
+{
+    /**
+     * Test methods with flags
+     *
+     * @test
+     * @dataProvider sameTypeMethodData
+     * @final
+     * @param Type $subject - the subject {@link Type} object
+     * @param Type $target - the target {@link Type} object
+     * @param int $flags - the flags to test
+     * @param bool $isSameTypeAs - the expected result
+     * @param bool $isSameObjectAs - the expected result
+     * @return void
+     */
+    final public function methodsShouldReturnCorrectBooleanValue(Type $subject, Type $target, int $flags, bool $isSameTypeAs, bool $isSameObjectAs): void
+    {
+        $this->assertEquals($isSameTypeAs, $subject->isSameTypeAs($target, $flags));
+        $this->assertEquals($isSameObjectAs, $subject->isSameObjectAs($target, $flags));
+    }
+
+    /**
+     * Test {@link TypeEquality::isSameTypeAs} throws exception
+     *
+     * @test
+     * @expectedException RuntimeException
+     * @final
+     * @return void
+     */
+    final public function shouldThrowAnException(): void
+    {
+        $subject = new class { // Note does not implement correct interface
+            use TypeEqualityHelperMethods {
+                isSameTypeAs as public isSameTypeAs;
+            }
+        };
+
+        $target = new class implements Type { // Correct interface
+            final public static function getType(): string
+            {
+                return 'test';
+            }
+        };
+
+        $subject->isSameTypeAs($target);
+    }
+
+    /**
+     * Data provider
+     *
+     * @final
+     * @return array
+     */
+    final public function sameTypeMethodData(): array
+    {
+        $one = new class implements Type {
+            use TypeEqualityHelperMethods {
+                isSameTypeAs as public isSameTypeAs;
+            }
+
+            use TypeEqualityHelperMethods {
+                isSameObjectAs as public isSameObjectAs;
+            }
+
+            final public static function getType(): string
+            {
+                return 'test';
+            }
+        };
+
+        $two = new class implements Type {
+            use TypeEqualityHelperMethods {
+                isSameTypeAs as public isSameTypeAs;
+            }
+
+            use TypeEqualityHelperMethods {
+                isSameObjectAs as public isSameObjectAs;
+            }
+
+            final public static function getType(): string
+            {
+                return 'test';
+            }
+        };
+
+        $three = new class implements Type {
+            use TypeEqualityHelperMethods {
+                isSameTypeAs as public isSameTypeAs;
+            }
+
+            use TypeEqualityHelperMethods {
+                isSameObjectAs as public isSameObjectAs;
+            }
+
+            final public static function getType(): string
+            {
+                return 'bar';
+            }
+        };
+
+        return [
+            'Same object with flags set IGNORE_OBJECT_TYPE' => [
+                $one,
+                $one,
+                TypeEquality::IGNORE_OBJECT_TYPE,
+                true,
+                true,
+            ],
+
+            'Same object with flags set IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $one,
+                TypeEquality::IGNORE_OBJECT_IDENTITY,
+                true,
+                true,
+            ],
+
+            'Same object with flags set IGNORE_OBJECT_IDENTITY | IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $one,
+                TypeEquality::IGNORE_OBJECT_IDENTITY | TypeEquality::IGNORE_OBJECT_IDENTITY,
+                true,
+                true,
+            ],
+
+            'Equal objects with flag set to IGNORE_OBJECT_TYPE' => [
+                $one,
+                $two,
+                TypeEquality::IGNORE_OBJECT_TYPE,
+                true,
+                false,
+            ],
+
+            'Not equal objects with flag set to IGNORE_OBJECT_TYPE' => [
+                $one,
+                $three,
+                TypeEquality::IGNORE_OBJECT_TYPE,
+                true,
+                false,
+            ],
+
+            'Equal objects with flag set to IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $two,
+                TypeEquality::IGNORE_OBJECT_IDENTITY,
+                true,
+                false,
+            ],
+
+            'Not equal objects with flag set to IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $three,
+                TypeEquality::IGNORE_OBJECT_IDENTITY,
+                false,
+                false,
+            ],
+
+            'Equal objects with flag set to IGNORE_OBJECT_TYPE | IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $two,
+                TypeEquality::IGNORE_OBJECT_IDENTITY | TypeEquality::IGNORE_OBJECT_TYPE,
+                true,
+                true,
+            ],
+
+            'Not equal objects with flag set to IGNORE_OBJECT_TYPE | IGNORE_OBJECT_IDENTITY' => [
+                $one,
+                $three,
+                TypeEquality::IGNORE_OBJECT_IDENTITY | TypeEquality::IGNORE_OBJECT_TYPE,
+                true,
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/Helpers/TypeEqualityHelperMethodsTest.php
+++ b/tests/Helpers/TypeEqualityHelperMethodsTest.php
@@ -159,7 +159,7 @@ final class TypeEqualityHelperMethodsTest extends TestCase
                 $two,
                 TypeEquality::IGNORE_OBJECT_IDENTITY,
                 true,
-                false,
+                true,
             ],
 
             'Not equal objects with flag set to IGNORE_OBJECT_IDENTITY' => [
@@ -167,7 +167,7 @@ final class TypeEqualityHelperMethodsTest extends TestCase
                 $three,
                 TypeEquality::IGNORE_OBJECT_IDENTITY,
                 false,
-                false,
+                true,
             ],
 
             'Equal objects with flag set to IGNORE_OBJECT_TYPE | IGNORE_OBJECT_IDENTITY' => [

--- a/tests/Helpers/TypeEqualityHelperMethodsTest.php
+++ b/tests/Helpers/TypeEqualityHelperMethodsTest.php
@@ -56,7 +56,7 @@ final class TypeEqualityHelperMethodsTest extends TestCase
         $subject = new class { // Note does not implement correct interface
             use TypeEqualityHelperMethods;
 
-            final public function foo(Type $type, int $flags): bool
+            final public function foo(Type $type, int $flags = null): bool
             {
                 return $this->isSameTypeAs($type, $flags);
             }


### PR DESCRIPTION
Add bitwise flags to `TypeEquality::equals` method and a couple of helper methods in `Helpers\TypeEqualityHelperMethods` to check against the value returned in `Type::getType` and against an objects internal PHP reference.